### PR TITLE
Disable vim-markdown folding

### DIFF
--- a/standard-vim/.vimrc
+++ b/standard-vim/.vimrc
@@ -34,6 +34,7 @@ Plug 'elixir-editors/vim-elixir'
 Plug 'mhinz/vim-mix-format'
 " Markdown language support - syntax highlighting, folding, and markdown-specific commands
 Plug 'plasticboy/vim-markdown'
+let g:vim_markdown_folding_disabled = 1
 " Git gutter - shows git changes in the sign column
 Plug 'airblade/vim-gitgutter'
 " Git integration - fugitive for git commands inside vim
@@ -300,7 +301,6 @@ endif
 
 " Custom visual selection highlight
 hi Visual guibg=#bd93f9 guifg=#282a36 ctermbg=magenta ctermfg=black
-
 
 
 

--- a/standard-vim/.vimrc
+++ b/standard-vim/.vimrc
@@ -34,7 +34,6 @@ Plug 'elixir-editors/vim-elixir'
 Plug 'mhinz/vim-mix-format'
 " Markdown language support - syntax highlighting, folding, and markdown-specific commands
 Plug 'plasticboy/vim-markdown'
-let g:vim_markdown_folding_disabled = 1
 " Git gutter - shows git changes in the sign column
 Plug 'airblade/vim-gitgutter'
 " Git integration - fugitive for git commands inside vim
@@ -57,6 +56,9 @@ Plug 'vim-airline/vim-airline-themes'
 " Show marks in sign column
 Plug 'kshenoy/vim-signature'
 call plug#end()
+
+" Markdown configuration
+let g:vim_markdown_folding_disabled = 1
 
 " Coc global extensions
 let g:coc_global_extensions = [
@@ -301,7 +303,6 @@ endif
 
 " Custom visual selection highlight
 hi Visual guibg=#bd93f9 guifg=#282a36 ctermbg=magenta ctermfg=black
-
 
 
 


### PR DESCRIPTION
## Summary
- disable vim-markdown folding in standard Vim config
- move vim-markdown config out of plugin block

## Testing
- not run (config change)