### PR TITLE
Enable Terraform LSP and format-on-save in standard Vim

### DIFF
--- a/standard-vim/.vimrc
+++ b/standard-vim/.vimrc
@@ -70,7 +70,8 @@ let g:coc_global_extensions = [
   \ 'coc-json',
   \ 'coc-html',
   \ 'coc-css',
-  \ 'coc-yaml'
+  \ 'coc-yaml',
+  \ 'coc-terraform'
   \ ]
 
 " Fern configuration
@@ -303,7 +304,6 @@ endif
 
 " Custom visual selection highlight
 hi Visual guibg=#bd93f9 guifg=#282a36 ctermbg=magenta ctermfg=black
-
 
 
 

--- a/standard-vim/coc-settings.json
+++ b/standard-vim/coc-settings.json
@@ -26,7 +26,8 @@
     "css",
     "scss",
     "less",
-    "yaml"
+    "yaml",
+    "terraform"
   ],
   "diagnostic.enable": true,
   "diagnostic.displayByAle": false,


### PR DESCRIPTION
## Summary
- add `coc-terraform` to standard Vim Coc extensions for Terraform LSP
- enable format-on-save for Terraform filetypes in `coc-settings.json`