### PR TITLE
Remove Elixir language support and tooling

### DIFF
--- a/standard-vim/.vimrc
+++ b/standard-vim/.vimrc
@@ -28,10 +28,6 @@ Plug 'jasonccox/vim-wayland-clipboard'
 
 " Rust language support - enhanced syntax highlighting, rustfmt integration, and Rust-specific commands
 Plug 'rust-lang/rust.vim'
-" Elixir language support - syntax highlighting, filetype detection, and indentation for all Elixir file types
-Plug 'elixir-editors/vim-elixir'
-" Elixir mix format integration - asynchronous formatting on save
-Plug 'mhinz/vim-mix-format'
 " Markdown language support - syntax highlighting, folding, and markdown-specific commands
 Plug 'plasticboy/vim-markdown'
 " Git gutter - shows git changes in the sign column
@@ -63,7 +59,6 @@ let g:vim_markdown_folding_disabled = 1
 " Coc global extensions
 let g:coc_global_extensions = [
   \ 'coc-rust-analyzer',
-  \ 'coc-elixir',
   \ 'coc-tsserver',
   \ 'coc-eslint',
   \ 'coc-prettier',
@@ -164,10 +159,6 @@ let g:fern#default_hidden=1
 " Auto-formatting configuration for Rust
 " Enable automatic rustfmt on save for Rust files
 let g:rustfmt_autosave = 1
-
-" Auto-formatting configuration for Elixir
-" Enable automatic mix format on save for Elixir files
-let g:mix_format_on_save = 1
 
 " TypeScript/JavaScript specific configurations
 " Enable auto-formatting for TypeScript/JavaScript files

--- a/standard-vim/coc-settings.json
+++ b/standard-vim/coc-settings.json
@@ -1,5 +1,4 @@
 {
-  "elixir.pathToElixirLS": "~/.elixir-ls/language_server.sh",
   "typescript.preferences.importModuleSpecifier": "relative",
   "typescript.suggest.autoImports": true,
   "typescript.updateImportsOnFileMove.enabled": "always",


### PR DESCRIPTION
## Summary
- Remove vim-elixir and vim-mix-format plugins
- Remove coc-elixir extension and ElixirLS path from coc-settings
- Remove mix format on save configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)